### PR TITLE
Adding changes in systemd tests for porting it to dist-git

### DIFF
--- a/execute/test-execute.sh
+++ b/execute/test-execute.sh
@@ -483,6 +483,7 @@ test_exec_stdio_file() {
     [[ $? -eq 0 ]]
 }
 
+test_exec_dynamic_user
 test_exec_workingdirectory
 test_exec_privatedevices
 test_exec_privatedevices_capabilities
@@ -509,7 +510,6 @@ test_exec_systemcallerrornumber
 test_exec_systemcallfilter
 test_exec_restrict_address_families
 test_exec_personality
-test_exec_dynamic_user
 #test_exec_unset_environment
 #test_exec_stdin_data
 #test_exec_stdio_file

--- a/journal/test-journal.sh
+++ b/journal/test-journal.sh
@@ -8,48 +8,48 @@ set -o pipefail
 
 # Skip empty lines
 ID=$(journalctl --new-id128 | sed -n 2p)
->/expected
+>/tmp/expected
 printf $'\n\n\n' | systemd-cat -t "$ID" --level-prefix false
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 ID=$(journalctl --new-id128 | sed -n 2p)
->/expected
+>/tmp/expected
 printf $'<5>\n<6>\n<7>\n' | systemd-cat -t "$ID" --level-prefix true
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 # Remove trailing spaces
 ID=$(journalctl --new-id128 | sed -n 2p)
-printf "Trailing spaces\n">/expected
+printf "Trailing spaces\n">/tmp/expected
 printf $'<5>Trailing spaces \t \n' | systemd-cat -t "$ID" --level-prefix true
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 ID=$(journalctl --new-id128 | sed -n 2p)
-printf "Trailing spaces\n">/expected
+printf "Trailing spaces\n">/tmp/expected
 printf $'Trailing spaces \t \n' | systemd-cat -t "$ID" --level-prefix false
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 # Don't remove leading spaces
 ID=$(journalctl --new-id128 | sed -n 2p)
-printf $' \t Leading spaces\n'>/expected
+printf $' \t Leading spaces\n'>/tmp/expected
 printf $'<5> \t Leading spaces\n' | systemd-cat -t "$ID" --level-prefix true
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 ID=$(journalctl --new-id128 | sed -n 2p)
-printf $' \t Leading spaces\n'>/expected
+printf $' \t Leading spaces\n'>/tmp/expected
 printf $' \t Leading spaces\n' | systemd-cat -t "$ID" --level-prefix false
 journalctl --sync
-journalctl -b -o cat -t "$ID" >/output
-cmp /expected /output
+journalctl -b -o cat -t "$ID" >/tmp/output
+cmp /tmp/expected /tmp/output
 
 # Don't lose streams on restart
 systemctl start forever-print-hola

--- a/tests.yml
+++ b/tests.yml
@@ -3,7 +3,6 @@
     - role: standard-test-beakerlib
       tags:
         - classic
-        - container
       tests:
         - basic
         - hostnamectl
@@ -38,3 +37,77 @@
         - systemd
         - nc
         - python                    # beakerlib-journalling requires python
+
+- hosts: localhost
+  roles:
+    - role: standard-test-beakerlib
+      tags:
+        - atomic
+      tests:
+        - basic
+        - hostnamectl
+        - tmpfiles
+        - killmode
+        - localectl
+        - loginctl
+        - timedatectl
+        - rlimits
+        - journal
+        - jobs
+        - dropin
+        - sched
+        - path
+        - execute
+        - activate
+        - modules-load
+        - timers
+# disabled due BZ#1494426
+#       - socket
+        - link
+        - issue-1981
+        - issue-2467
+        - issue-3166
+# disabled due BZ#1493478
+#       - network
+      required_packages:
+        - ethtool                   # link tests needs this package
+
+- hosts: localhost
+  roles:
+    - role: standard-test-beakerlib
+      tags:
+        - container
+      tests:
+        - basic
+        - hostnamectl
+        - tmpfiles
+        - killmode
+        - localectl
+        - loginctl
+        - timedatectl
+        - rlimits
+        - journal
+        - jobs
+        - dropin
+        - sched
+        - path
+        - execute
+        - activate
+        - modules-load
+        - timers
+# disabled due BZ#1494426
+#       - socket
+        - link
+        - issue-1981
+        - issue-2467
+        - issue-3166
+# disabled due BZ#1493478
+#       - network
+      required_packages:
+        - ethtool                   # link tests needs this package
+        - findutils                 # beakerlib needs find command
+        - lsof                      # socket test needs this package
+        - systemd
+        - policycoreutilsi
+        - nc
+        - python


### PR DESCRIPTION
1. journal/test-journal.sh script modified for atomic tag, to execute under atomic host. 
2. Modified execute/test-execute.sh script. Added workaround with moving "test_exec_dynamic_user" tests on 1st position. Debugged it for under classic and atomic tags on Fedora26, 26, Rawhide, all tests passed successfully. 

3. Modified tests.yml, added atomic tags 

Results for classic mode:
  PLAY RECAP *********************************************************************
    localhost                  : ok=20   changed=10   unreachable=0    failed=0   

    PASS basic
    PASS hostnamectl
    PASS tmpfiles
    PASS killmode
    PASS localectl
    PASS loginctl
    PASS timedatectl
    PASS rlimits
    PASS journal
    PASS jobs
    PASS dropin
    PASS sched
    PASS path
    PASS execute
    PASS activate
    PASS modules-load
    PASS link
    PASS issue-1981
    PASS issue-2467
    PASS issue-3166

- Results for atomic mode
PLAY RECAP *********************************************************************
    /home/esaka/package_testing/upstreamfirst/systemd/atomic.qcow2 : ok=20   changed=11   unreachable=0    failed=0   

    [root@localhost systemd]# qemu-system-x86_64: terminating on signal 15 from pid 8749 (python)

    PASS basic
    PASS hostnamectl
    PASS tmpfiles
    PASS killmode
    PASS localectl
    PASS loginctl
    PASS timedatectl
    PASS rlimits
    PASS journal
    PASS jobs
    PASS dropin
    PASS sched
    PASS path
    PASS execute
    PASS activate
    PASS modules-load
    PASS link
    PASS issue-1981
    PASS issue-2467
    PASS issue-3166